### PR TITLE
Spark version bump to 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM sequenceiq/hadoop-docker:2.6.0
 MAINTAINER antlypls
 
 #support for Hadoop 2.6.0
-RUN curl -s http://d3kbcqa49mib13.cloudfront.net/spark-1.6.0-bin-hadoop2.6.tgz | tar -xz -C /usr/local/
-RUN cd /usr/local && ln -s spark-1.6.0-bin-hadoop2.6 spark
+RUN curl -s https://www.apache.org/dist/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz | tar -xz -C /usr/local/
+RUN cd /usr/local && ln -s spark-1.6.1-bin-hadoop2.6 spark
 ENV SPARK_HOME /usr/local/spark
 RUN mkdir $SPARK_HOME/yarn-remote-client
 ADD yarn-remote-client $SPARK_HOME/yarn-remote-client
 
-RUN $BOOTSTRAP && $HADOOP_PREFIX/bin/hdfs dfsadmin -safemode leave && $HADOOP_PREFIX/bin/hdfs dfs -put $SPARK_HOME-1.6.0-bin-hadoop2.6/lib /spark
+RUN $BOOTSTRAP && $HADOOP_PREFIX/bin/hdfs dfsadmin -safemode leave && $HADOOP_PREFIX/bin/hdfs dfs -put $SPARK_HOME-1.6.1-bin-hadoop2.6/lib /spark
 
 ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
 ENV PATH $PATH:$SPARK_HOME/bin:$HADOOP_PREFIX/bin

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@ Apache Spark on Docker
 ==========
 
 > This is a fork of https://github.com/sequenceiq/docker-spark repository
-> that just provides Spark 1.6.0
+> that just provides Spark 1.6.1
 
 This repository contains a Docker file to build a Docker image with Apache Spark.
 This Docker image depends on [Hadoop Docker](https://github.com/sequenceiq/hadoop-docker) image.
 
 ##Pull the image from Docker Repository
 ```
-docker pull antlypls/spark:1.6.0
+docker pull antlypls/spark:1.6.1
 ```
 
 ## Building the image
 ```
-docker build --rm -t antlypls/spark:1.6.0 .
+docker build --rm -t antlypls/spark:1.6.1 .
 ```
 
 ## Running the image
@@ -23,16 +23,16 @@ docker build --rm -t antlypls/spark:1.6.0 .
 * in your /etc/hosts file add $(boot2docker ip) as host 'sandbox' to make it easier to access your sandbox UI
 * open yarn UI ports when running container
 ```
-docker run -it -p 8088:8088 -p 8042:8042 -h sandbox antlypls/spark:1.6.0 bash
+docker run -it -p 8088:8088 -p 8042:8042 -h sandbox antlypls/spark:1.6.1 bash
 ```
 or
 ```
-docker run -d -h sandbox antlypls/spark:1.6.0 -d
+docker run -d -h sandbox antlypls/spark:1.6.1 -d
 ```
 
 ## Versions
 ```
-Hadoop 2.6.0 and Apache Spark v1.6.0 on Centos
+Hadoop 2.6.0 and Apache Spark v1.6.1 on Centos
 ```
 
 ## Testing
@@ -70,7 +70,7 @@ spark-submit \
 --driver-memory 1g \
 --executor-memory 1g \
 --executor-cores 1 \
-$SPARK_HOME/lib/spark-examples-1.6.0-hadoop2.6.0.jar
+$SPARK_HOME/lib/spark-examples-1.6.1-hadoop2.6.0.jar
 ```
 
 Estimating Pi (yarn-client mode):
@@ -83,5 +83,5 @@ spark-submit \
 --driver-memory 1g \
 --executor-memory 1g \
 --executor-cores 1 \
-$SPARK_HOME/lib/spark-examples-1.6.0-hadoop2.6.0.jar
+$SPARK_HOME/lib/spark-examples-1.6.1-hadoop2.6.0.jar
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; 
 sed s/HOSTNAME/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/core-site.xml.template > /usr/local/hadoop/etc/hadoop/core-site.xml
 
 # setting spark defaults
-echo spark.yarn.jar hdfs:///spark/spark-assembly-1.6.0-hadoop2.6.0.jar > $SPARK_HOME/conf/spark-defaults.conf
+echo spark.yarn.jar hdfs:///spark/spark-assembly-1.6.1-hadoop2.6.0.jar > $SPARK_HOME/conf/spark-defaults.conf
 cp $SPARK_HOME/conf/metrics.properties.template $SPARK_HOME/conf/metrics.properties
 
 service sshd start

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,3 +30,4 @@ then
 else
 	/bin/bash -c "$*"
 fi
+tail -f /dev/null


### PR DESCRIPTION
Also this container exited for me because of the bootstrap.sh exit, so I've added a hack in there to keep the container alive.

